### PR TITLE
[FIX] django-ninja 1.5.0 breaking changes

### DIFF
--- a/celeryanalytics/api.py
+++ b/celeryanalytics/api.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 api = NinjaAPI(title="Celery API", version="0.0.1",
-               urls_namespace='celery:api', auth=django_auth, csrf=True)  # ,
+               urls_namespace='celery:api', auth=django_auth)  # ,
 # openapi_url=settings.DEBUG and "/openapi.json" or "")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 dynamic = [ "description", "version" ]
 dependencies = [
     "allianceauth<5,>=3",
-    "django-ninja>=0.19.1",
+    "django-ninja>=1.0,<2",
 ]
 
 urls.Homepage = "https://github.com/Solar-Helix-Independent-Transport/allianceauth-celeryanalytics"


### PR DESCRIPTION
django-ninja 1.5.0 breaks celeryanalytics due to vitalik/django-ninja#1524 . According to the docs (https://django-ninja.dev/reference/csrf/) csrf is on by default when using `auth=django_auth` in django ninja v1, so removing the parameter doesn't change the behaviour. Bump the minimum version of django-ninja to v1 since it's when this default has been introduced, also the major version has been tested in the wild for the past 2 years. Fixes Solar-Helix-Independent-Transport/allianceauth-celeryanalytics#10